### PR TITLE
Add basic CLI tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic>=2.0.0
 python-dotenv>=0.19.0
 requests>=2.26.0
 typer>=0.9.0
+pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from typer.testing import CliRunner
+import cmdgen
+
+runner = CliRunner()
+
+def dummy_load_api_key(settings):
+    return "testkey"
+
+def dummy_make_api_request(settings, api_key, prompt):
+    return cmdgen.APIResponse(output=[{"content": [{"text": "echo test"}]}])
+
+class DummyHistory:
+    def append_string(self, text):
+        pass
+
+class DummySession:
+    def __init__(self):
+        self.history = DummyHistory()
+    def prompt(self, *args, **kwargs):
+        return "test"
+
+def dummy_setup_prompt_session(settings):
+    return DummySession()
+
+def setup(monkeypatch):
+    monkeypatch.setattr(cmdgen, "load_api_key", dummy_load_api_key)
+    monkeypatch.setattr(cmdgen, "make_api_request", dummy_make_api_request)
+    monkeypatch.setattr(cmdgen, "setup_prompt_session", dummy_setup_prompt_session)
+
+
+def test_quiet_flag(monkeypatch):
+    setup(monkeypatch)
+    result = runner.invoke(cmdgen.app, ["--quiet", "--prompt", "test"])
+    assert result.exit_code == 0
+
+
+def test_quiet_output(monkeypatch):
+    setup(monkeypatch)
+    result = runner.invoke(cmdgen.app, ["--quiet", "--prompt", "test"])
+    assert "echo test" in result.stdout


### PR DESCRIPTION
## Summary
- add pytest to requirements
- add basic Typer CLI tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840e35c6364832eba68e3f37cf6384a