### PR TITLE
Fix --quiet flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or consult documentation.
   - Copy to X11 clipboard
   - Direct command line output
 - Token usage statistics
-- Quiet mode for scripting
+- Quiet mode for scripting (automatically enabled when output is not a terminal)
 - Direct prompt input for automation
 
 ## Installation
@@ -53,7 +53,7 @@ request in natural language.
 - `-t, --tmux`: Copy command to tmux paste buffer
 - `-x, --xsel`: Copy command to X11 clipboard
 - `-p, --prompt TEXT`: Provide prompt directly (bypasses terminal input)
-- `-q, --quiet`: Minimal output (no borders, no progress)
+- `-q, --quiet`: Minimal output (no borders, no progress). Automatically enabled when piping output.
 
 ### Examples
 
@@ -79,13 +79,13 @@ request in natural language.
 
 5. Use in a script:
 ```bash
-command=$(./cmdgen.py -q -p "list processes")
+command=$(./cmdgen.py -p "list processes")
 echo "Generated command: $command"
 ```
 
 6. Pipe to another command:
 ```bash
-./cmdgen.py -q -p "find files" | xargs -I {} sh -c "{}"
+./cmdgen.py -p "find files" | xargs -I {} sh -c "{}"
 ```
 
 ### Environment Variables

--- a/cmdgen.py
+++ b/cmdgen.py
@@ -189,16 +189,16 @@ def main(
         help="Provide prompt directly (bypasses terminal input)"
     ),
     quiet: bool = typer.Option(
-        None,
+        False,
         "--quiet",
         "-q",
-        help="Minimal output (no borders, no progress)"
+        help="Minimal output (no borders, no progress)",
+        is_flag=True,
     )
 ):
     """Ask for a shell command from OpenAI based on a prompt."""
-    # Set quiet mode if stdout is not a terminal or --quiet is specified
-    if quiet is None:
-        quiet = not is_terminal()
+    # Enable quiet mode when stdout is not a terminal or --quiet is specified
+    quiet = quiet or not is_terminal()
 
     settings = load_settings()
     api_key = load_api_key(settings)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,13 @@ def test_quiet_output(monkeypatch):
     result = runner.invoke(cmdgen.app, ["--quiet", "--prompt", "test"])
     assert "echo test" in result.stdout
 
+def test_quiet_auto_when_not_terminal(monkeypatch):
+    setup(monkeypatch)
+    monkeypatch.setattr(cmdgen, "is_terminal", lambda: False)
+    result = runner.invoke(cmdgen.app, ["--prompt", "test"])
+    assert result.exit_code == 0
+    assert "echo test" in result.stdout
+    assert "Generated Command" not in result.stdout
 
 class CallCounter:
     def __init__(self):


### PR DESCRIPTION
## Summary
- make `--quiet` a boolean flag
- update README with new flag behavior
- add test for automatic quiet mode when output isn't a terminal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840ec666d54832ea6fce2ca2b573f1c