### PR TITLE
Fix Typer deprecation warning

### DIFF
--- a/cmdgen.py
+++ b/cmdgen.py
@@ -193,7 +193,6 @@ def main(
         "--quiet",
         "-q",
         help="Minimal output (no borders, no progress)",
-        is_flag=True,
     )
 ):
     """Ask for a shell command from OpenAI based on a prompt."""


### PR DESCRIPTION
## Summary
- remove `is_flag` from `--quiet` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840efbe69ec832e99180ac0908b9c4e