### PR TITLE
Use openai client for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The file is automatically trimmed to the last `MAX_HISTORY` entries.
 - prompt_toolkit
 - pydantic
 - python-dotenv
-- requests
+- openai
 - typer
 - xsel (for X11 clipboard support)
 - tmux (for tmux buffer support)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ rich>=10.0.0
 prompt_toolkit>=3.0.0
 pydantic>=2.0.0
 python-dotenv>=0.19.0
-requests>=2.26.0
+openai>=1.0.0
 typer>=0.9.0
 pytest

--- a/tests/stubs/openai/__init__.py
+++ b/tests/stubs/openai/__init__.py
@@ -1,0 +1,7 @@
+class OpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+    class responses:
+        @staticmethod
+        def create(*args, **kwargs):
+            raise NotImplementedError("OpenAI API is not available in test env")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+import sys
+import pathlib
+TEST_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TEST_DIR / "stubs"))
+sys.path.insert(0, str(TEST_DIR.parent))
+import cmdgen
+
+class DummyResponse:
+    def __init__(self):
+        self.called = False
+    def model_dump(self):
+        return {"output": [{"content": [{"text": "cmd"}]}], "usage": {"tokens": 1}}
+
+class DummyClient:
+    def __init__(self):
+        self.responses = self
+        self.created_with = None
+    def create(self, **kwargs):
+        self.created_with = kwargs
+        return DummyResponse()
+
+def test_make_api_request_uses_openai(monkeypatch):
+    dummy_client = DummyClient()
+    def openai_factory(**kwargs):
+        return dummy_client
+    monkeypatch.setattr(cmdgen.openai, "OpenAI", openai_factory)
+    resp = cmdgen.make_api_request(cmdgen.Settings(api_url="url", model="model"), "key", "prompt")
+    assert isinstance(resp, cmdgen.APIResponse)
+    assert dummy_client.created_with["model"] == "model"
+    assert dummy_client.created_with["input"][1]["content"] == "prompt"
+

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,3 +1,8 @@
+import sys
+import pathlib
+TEST_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(TEST_DIR / "stubs"))
+sys.path.insert(0, str(TEST_DIR.parent))
 import cmdgen
 
 def test_trim_history_truncates(tmp_path):


### PR DESCRIPTION
## Summary
- switch API requests to use `openai` python module
- add stub `openai` module for tests
- update requirements and docs
- test stats output and API usage
- move stub under `tests/stubs` so it doesn't shadow real module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840f2a50b5c832eb6767897c16c9467