### PR TITLE
Remove custom API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ The following environment variables can be set to customize the tool's behavior:
 - `HISTORY_FILE`: Path to the history file (default: `~/.cmdgen_history`)
 - `MAX_HISTORY`: Maximum number of history entries to keep (default: `1000`)
 - `MODEL`: OpenAI model to use (default: `gpt-4o`)
-- `API_URL`: OpenAI API URL (default: `https://api.openai.com/v1/responses`)
 - `DEVELOPER_PROMPT`: Custom developer prompt
 
 ### History

--- a/cmdgen.py
+++ b/cmdgen.py
@@ -29,7 +29,6 @@ class Settings(BaseModel):
     history_file: Path = Field(default=Path.home() / '.cmdgen_history')
     max_history: int = Field(default=1000)
     model: str = Field(default='gpt-4o')
-    api_url: str = Field(default='https://api.openai.com/v1/responses')
     developer_prompt: str = Field(
         default='Output a shell command to satisfy the user prompt. '
                 'Do not include any markdown in the output, just the command. '
@@ -49,7 +48,6 @@ def load_settings() -> Settings:
         history_file=os.getenv('HISTORY_FILE', str(Path.home() / '.cmdgen_history')),
         max_history=int(os.getenv('MAX_HISTORY', '1000')),
         model=os.getenv('MODEL', 'gpt-4o'),
-        api_url=os.getenv('API_URL', 'https://api.openai.com/v1/responses'),
         developer_prompt=os.getenv('DEVELOPER_PROMPT', Settings().developer_prompt)
     )
 
@@ -96,7 +94,7 @@ def trim_history(settings: Settings) -> None:
 def make_api_request(settings: Settings, api_key: str, prompt: str) -> APIResponse:
     """Make the OpenAI API request and return the response."""
     try:
-        client = openai.OpenAI(api_key=api_key, base_url=settings.api_url)
+        client = openai.OpenAI(api_key=api_key)
         resp = client.responses.create(
             model=settings.model,
             input=[

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def test_make_api_request_uses_openai(monkeypatch):
     def openai_factory(**kwargs):
         return dummy_client
     monkeypatch.setattr(cmdgen.openai, "OpenAI", openai_factory)
-    resp = cmdgen.make_api_request(cmdgen.Settings(api_url="url", model="model"), "key", "prompt")
+    resp = cmdgen.make_api_request(cmdgen.Settings(model="model"), "key", "prompt")
     assert isinstance(resp, cmdgen.APIResponse)
     assert dummy_client.created_with["model"] == "model"
     assert dummy_client.created_with["input"][1]["content"] == "prompt"


### PR DESCRIPTION
## Summary
- remove `api_url` field from settings and stop using custom base URL
- drop `API_URL` from documentation
- update API tests for new Settings signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f82b901c832ebd69f06f7778c5b0