### PR TITLE
Fix history filtering and update tests

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -21,3 +21,11 @@ def test_trim_history_no_change(tmp_path):
     settings = cmdgen.Settings(history_file=history_file, max_history=5)
     cmdgen.trim_history(settings)
     assert history_file.read_text().splitlines() == lines
+
+
+def test_setup_prompt_session_filters_prompts(tmp_path):
+    histfile = tmp_path / "hist"
+    histfile.write_text("\n# ts1\n+foo\n\n# ts2\n+bar\n")
+    settings = cmdgen.Settings(history_file=histfile)
+    session = cmdgen.setup_prompt_session(settings, persistent=False)
+    assert session.history.get_strings() == ["foo", "bar"]

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -139,8 +139,9 @@ def test_repl_history_summary_written(monkeypatch, tmp_path):
     settings = cmdgen.Settings(history_file=tmp_path / "hist")
     cmdgen.run_repl(settings, "key", None, True, False, False)
     lines = settings.history_file.read_text().splitlines()
-    assert lines[0].startswith("# ")
-    assert lines[1] == "+summary line"
+    assert lines[0] == ""
+    assert lines[1].startswith("# ")
+    assert lines[2] == "+summary line"
 
 
 def test_repl_summary_uses_context(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- filter REPL history to skip timestamps and `+` prefix
- keep `+` out of loaded prompt history
- write a blank line before history timestamps in REPL
- add regression tests for history filtering
- update REPL history summary test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c46c2a00832eaa45016bd7b628e1