### PR TITLE
Fix token stats parsing and CLI option

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,15 @@ class DummyResponse:
     def __init__(self):
         self.called = False
     def model_dump(self):
-        return {"output": [{"content": [{"text": "cmd"}]}], "usage": {"tokens": 1}}
+        return {
+            "output": [{"content": [{"text": "cmd"}]}],
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 0,
+                "input_tokens_details": {"cached_tokens": 0},
+                "total_tokens": 1,
+            },
+        }
 
 class DummyClient:
     def __init__(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,10 @@ def dummy_load_api_key(settings):
     return "testkey"
 
 def dummy_make_api_request(settings, api_key, prompt):
-    return cmdgen.APIResponse(output=[{"content": [{"text": "echo test"}]}], usage={"tokens": 1})
+    return cmdgen.APIResponse(
+        output=[{"content": [{"text": "echo test"}]}],
+        usage={"input_tokens": 1, "output_tokens": 0, "input_tokens_details": {"cached_tokens": 0}, "total_tokens": 1},
+    )
 
 class DummyHistory:
     def append_string(self, text):
@@ -67,7 +70,17 @@ def test_stats_flag(monkeypatch):
     counter = CallCounter()
     monkeypatch.setattr(cmdgen, "display_stats", counter)
     monkeypatch.setattr(cmdgen, "is_terminal", lambda: True)
-    runner.invoke(cmdgen.app, ["--prompt", "test", "--stats"])
+    runner.invoke(cmdgen.app, ["--prompt", "test", "--stats=basic"])
+    assert counter.count == 1
+
+
+def test_stats_debug(monkeypatch):
+    setup(monkeypatch)
+    counter = CallCounter()
+    monkeypatch.setattr(cmdgen, "display_stats", counter)
+    monkeypatch.setattr(cmdgen, "is_terminal", lambda: True)
+    result = runner.invoke(cmdgen.app, ["--prompt", "test", "--stats=debug"])
+    assert result.exit_code == 0
     assert counter.count == 1
 
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -68,7 +68,12 @@ def test_cli_invokes_repl_by_default(monkeypatch):
 
 
 def test_repl_stats_output(monkeypatch, tmp_path):
-    usage = {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3, "cached_tokens": 0}
+    usage = {
+        "input_tokens": 1,
+        "output_tokens": 2,
+        "input_tokens_details": {"cached_tokens": 0},
+        "total_tokens": 3,
+    }
     inputs = ["foo", "exit"]
     setup_common(monkeypatch, inputs)
     stats_calls = []


### PR DESCRIPTION
## Summary
- add helpers to parse token usage
- show stats for summary API call and cumulative totals
- allow specifying stats level via `--stats=<level>`
- update tests for new stats handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cd64f94c832e86c20c01673b75a3